### PR TITLE
Travis CI: Remove sudo tag and Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,16 @@ matrix:
     - python: 3.7
   include:
     - python: 2.7
-    #- python: 3.4
     #- python: 3.5
     #- python: 3.6
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
   # - pip install -r requirements.txt
   - pip install flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,13 @@ matrix:
     - python: 3.7
   include:
     - python: 2.7
-    #- python: 3.5
-    #- python: 3.6
     - python: 3.7
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
   # - pip install -r requirements.txt
   - pip install flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:


### PR DESCRIPTION
Add a few more tests.

Python 3.4 is End of Life: https://devguide.python.org/devcycle/#end-of-life-branches

[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"